### PR TITLE
Add support for images with EXIF orientation tag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jinja2~=2.11.3
 Pillow~=11.1.0
+piexif~=1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 jinja2~=2.11.3
-Pillow~=8.1.0
+Pillow~=11.1.0


### PR DESCRIPTION
Images taken with digital cameras have "EXIF" metadata included to indicate information about the photo.

The relevant EXIF tag is `orientation`, which indicates if the orientation of the device was different from how the photo is stored on the device. Most modern photo viewers check for this tag when opening photos and rotate the image automatically. This pull request implements that feature.

It also pulls the latest version of the Pillow package, as the version in `requirements.txt` was unable to compile on my device using Python 3.11.